### PR TITLE
Fix for using relative URLs

### DIFF
--- a/CSharp.oDesk/Api/Impl/oDeskTemplate.cs
+++ b/CSharp.oDesk/Api/Impl/oDeskTemplate.cs
@@ -43,7 +43,7 @@ namespace CSharp.oDesk.Api.Impl
     /// <author>Scott Smith</author>
     public sealed class oDeskTemplate : AbstractOAuth1ApiBinding, IoDesk 
     {
-        private static readonly Uri ApiUriBase = new Uri("http://www.odesk.com/api/");
+        private static readonly Uri ApiUriBase = new Uri("https://www.odesk.com/api/");
 
         /// <summary>
         /// Create a new instance of <see cref="oDeskTemplate"/>.


### PR DESCRIPTION
Changed HTTP to HTTPS, because:
- oDesk API Reference https://developers.odesk.com/#getting-started_request-structure states "all API requests must be made over HTTPS".
- Relative URLs simply didn't work when ApiUriBase used HTTP.
